### PR TITLE
Ignore WSDL files in output directory.

### DIFF
--- a/src/main/java/de/codecentric/cxf/BootCxfMojo.java
+++ b/src/main/java/de/codecentric/cxf/BootCxfMojo.java
@@ -190,6 +190,11 @@ public class BootCxfMojo extends AbstractMojo {
         String[] extension = {"wsdl"};
         Collection<File> wsdls = FileUtils.listFiles(buildDirectory, extension, true);
 
+        if(mavenProject != null) {
+            String targetDirectory = mavenProject.getBuild().getOutputDirectory().replaceAll("classes$", "");
+            wsdls.removeIf(f -> f.getAbsolutePath().startsWith(targetDirectory));
+        }
+
         Optional<File> wsdl = wsdls.stream().findFirst();
 
         if(wsdl.isPresent()) {


### PR DESCRIPTION
This fixes #19, where the code generation is potentially skipped in
case WSDL files are present in the output directory.